### PR TITLE
[PLA-1689] Fix typo in migration.

### DIFF
--- a/database/migrations/2023_12_06_232758_add_listing_id_to_marketplace_sales_table.php
+++ b/database/migrations/2023_12_06_232758_add_listing_id_to_marketplace_sales_table.php
@@ -24,12 +24,12 @@ return new class () extends Migration {
      */
     public function down(): void
     {
-        Schema::table('marketplace_sales', function (Blueprint $table) {
-            $table->dropColumn('listing_id');
-        });
-
         Schema::table('marketplace_listings', function (Blueprint $table) {
             $table->renameColumn('listing_chain_id', 'listing_id');
+        });
+
+        Schema::table('marketplace_sales', function (Blueprint $table) {
+            $table->dropColumn('listing_chain_id');
         });
     }
 };


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a typo in the `down` method of the migration file `2023_12_06_232758_add_listing_id_to_marketplace_sales_table.php` to correctly drop the `listing_chain_id` column instead of `listing_id`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>2023_12_06_232758_add_listing_id_to_marketplace_sales_table.php</strong><dd><code>Fix column name typo in migration rollback method.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

database/migrations/2023_12_06_232758_add_listing_id_to_marketplace_sales_table.php
<li>Corrected the column name to be dropped in the <code>down</code> method.<br> <li> Added dropping of <code>listing_chain_id</code> column instead of <code>listing_id</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-marketplace/pull/44/files#diff-0391751614a081f9532e8902f1e260af4104cae1febab5efd38124bbe79551c2">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

