### PR TITLE
[PLA-1414] Fix translation string key.

### DIFF
--- a/src/GraphQL/Unions/ListingStateUnion.php
+++ b/src/GraphQL/Unions/ListingStateUnion.php
@@ -17,7 +17,7 @@ class ListingStateUnion extends UnionType implements PlatformGraphQlUnion
     {
         return [
             'name' => 'ListingState',
-            'description' => __('enjin-platform-marketplace::union.listing_state.description'),
+            'description' => __('enjin-platform-marketplace::enum.listing_state.description'),
         ];
     }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrected the translation string key in the `attributes` method of `ListingStateUnion` to ensure the description is properly retrieved.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ListingStateUnion.php</strong><dd><code>Fix translation string key in ListingStateUnion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Unions/ListingStateUnion.php

- Corrected the translation string key in the `attributes` method.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-marketplace/pull/62/files#diff-fa4f6930665018c1fa5a1f05b4abe9ed37e30e3d0e3f6c0e8750fe64824d96f4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

