### PR TITLE
[PLA-2146] Adds migration to fix the values

### DIFF
--- a/database/migrations/2025_01_17_110200_fix_types_on_marketplace_listings_table.php
+++ b/database/migrations/2025_01_17_110200_fix_types_on_marketplace_listings_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Enjin\Platform\Marketplace\Models\MarketplaceListing;
+use Enjin\Platform\Marketplace\Enums\ListingType;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        MarketplaceListing::where('type', ListingType::FIXED_PRICE->value)->update(['type' => ListingType::FIXED_PRICE->name]);
+        MarketplaceListing::where('type', ListingType::AUCTION->value)->update(['type' => ListingType::AUCTION->name]);
+        MarketplaceListing::where('type', ListingType::OFFER->value)->update(['type' => ListingType::OFFER->name]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {}
+};


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Adds a migration to fix `type` values in `MarketplaceListing`.

- Updates `type` values to use `name` instead of `value`.

- Ensures consistency in `type` field for `MarketplaceListing`.

- Includes a no-op `down` method for migration reversal.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>2025_01_17_110200_fix_types_on_marketplace_listings_table.php</strong><dd><code>Add migration to update `type` values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

database/migrations/2025_01_17_110200_fix_types_on_marketplace_listings_table.php

<li>Introduces a migration to update <code>type</code> values in <code>MarketplaceListing</code>.<br> <li> Converts <code>type</code> values from <code>value</code> to <code>name</code> for consistency.<br> <li> Implements an empty <code>down</code> method for migration reversal.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-marketplace/pull/77/files#diff-fa49666609cdfea7dcc862f4c5e4ed6be33ae264725f1bf0304677acc71075a4">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information