### PR TITLE
[PLA-2214] Adds support for new CreateListing on v1020

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-json": "*",
         "ext-openssl": "*",
         "ext-gmp": "*",
-        "enjin/platform-core": "*",
+        "enjin/platform-core": "dev-master",
         "rebing/graphql-laravel": "*",
         "spatie/laravel-package-tools": "*",
         "phrity/websocket": "*"

--- a/composer.json
+++ b/composer.json
@@ -30,18 +30,18 @@
         "phrity/websocket": "*"
     },
     "require-dev": {
-        "laravel/pint": "^1.19",
-        "nunomaduro/collision": "^8.5",
-        "larastan/larastan": "^3.0",
-        "orchestra/testbench": "^9.9",
+        "laravel/pint": "^1.21",
+        "nunomaduro/collision": "^8.7",
+        "larastan/larastan": "^3.2",
+        "orchestra/testbench": "^9.12",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/php-code-coverage": "^11.0",
-        "phpunit/phpunit": "^11.0",
+        "phpunit/phpunit": "^11.5",
         "rector/rector": "^2.0",
         "roave/security-advisories": "dev-latest",
-        "spatie/laravel-ray": "^1.39"
+        "spatie/laravel-ray": "^1.40"
     },
     "autoload": {
         "psr-4": {

--- a/lang/en/deprecated.php
+++ b/lang/en/deprecated.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'auction_data.field.startBlock' => 'The start block has been moved to the main extrinsic arguments.',
+];

--- a/lang/en/type.php
+++ b/lang/en/type.php
@@ -24,7 +24,7 @@ return [
     'auction_state.description' => 'State of an auction listing.',
     'auction_state.field.highestBid' => 'The highest bid.',
     'auction_data.description' => 'Immutable data specifically for an auction.',
-    'auction_data.field.startBlock' => 'The block number the auction starts at.',
+    'auction_data.field.startBlock' => '(DEPRECATED) The block number the auction starts at. Use the field startBlock instead.',
     'auction_data.field.endBlock' => 'The block number the auction ends at.',
     'marketplace_bid.description' => 'The auction bid.',
     'marketplace_bid.field.bidder' => 'The account who placed the bid.',

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -26,7 +26,7 @@
     <env name="DB_CONNECTION" value="mysql"/>
     <env name="CACHE_STORE" value="redis"/>
     <env name="CHAIN" value="substrate"/>
-    <env name="NETWORK" value="local"/>
+    <env name="NETWORK" value="canary-matrixchain"/>
     <env name="DAEMON_ACCOUNT" value="0x6a03b1a3d40d7e344dfb27157931b14b59fe2ff11d7352353321fe400e956802"/>
   </php>
   <source>

--- a/src/GraphQL/Mutations/CreateListingMutation.php
+++ b/src/GraphQL/Mutations/CreateListingMutation.php
@@ -46,7 +46,6 @@ class CreateListingMutation extends Mutation implements PlatformBlockchainTransa
     /**
      * Get the mutation's attributes.
      */
-    #[\Override]
     public function attributes(): array
     {
         return [
@@ -58,7 +57,6 @@ class CreateListingMutation extends Mutation implements PlatformBlockchainTransa
     /**
      * Get the mutation's return type.
      */
-    #[\Override]
     public function type(): Type
     {
         return GraphQL::type('Transaction!');
@@ -67,7 +65,6 @@ class CreateListingMutation extends Mutation implements PlatformBlockchainTransa
     /**
      * Get the mutation's arguments definition.
      */
-    #[\Override]
     public function args(): array
     {
         return [
@@ -112,7 +109,7 @@ class CreateListingMutation extends Mutation implements PlatformBlockchainTransa
         ResolveInfo $resolveInfo,
         Closure $getSelectFields,
     ) {
-        $encodedData = TransactionSerializer::encode($this->getMutationName(), static::getEncodableParams(
+        $encodedData = TransactionSerializer::encode($this->getMutationName() . (currentSpec() >= 1020 ? '' : 'V1013'), static::getEncodableParams(
             makeAssetId: new MultiTokensTokenAssetIdParams(
                 Arr::get($args, 'makeAssetId.collectionId'),
                 $this->encodeTokenId(Arr::get($args, 'makeAssetId'))
@@ -133,7 +130,6 @@ class CreateListingMutation extends Mutation implements PlatformBlockchainTransa
         );
     }
 
-    #[\Override]
     public static function getEncodableParams(...$params): array
     {
         $makeAsset = Arr::get($params, 'makeAssetId', new MultiTokensTokenAssetIdParams('0', '0'));
@@ -159,7 +155,9 @@ class CreateListingMutation extends Mutation implements PlatformBlockchainTransa
             'takeAssetId' => $takeAsset->toEncodable(),
             'amount' => gmp_init($amount),
             'price' => gmp_init($price),
+            'startBlock' => null, // TODO: New feature from v1020, to be implemented
             'salt' => HexConverter::stringToHexPrefixed($salt),
+            'usesWhitelist' => false, // TODO: New feature from v1020, to be implemented
             'listingData' => $listingData->toEncodable(),
             'depositor' => null,
         ];

--- a/src/GraphQL/Mutations/CreateListingMutation.php
+++ b/src/GraphQL/Mutations/CreateListingMutation.php
@@ -46,6 +46,7 @@ class CreateListingMutation extends Mutation implements PlatformBlockchainTransa
     /**
      * Get the mutation's attributes.
      */
+    #[\Override]
     public function attributes(): array
     {
         return [
@@ -65,6 +66,7 @@ class CreateListingMutation extends Mutation implements PlatformBlockchainTransa
     /**
      * Get the mutation's arguments definition.
      */
+    #[\Override]
     public function args(): array
     {
         return [
@@ -130,6 +132,7 @@ class CreateListingMutation extends Mutation implements PlatformBlockchainTransa
         );
     }
 
+    #[\Override]
     public static function getEncodableParams(...$params): array
     {
         $makeAsset = Arr::get($params, 'makeAssetId', new MultiTokensTokenAssetIdParams('0', '0'));

--- a/src/GraphQL/Mutations/CreateListingMutation.php
+++ b/src/GraphQL/Mutations/CreateListingMutation.php
@@ -46,6 +46,7 @@ class CreateListingMutation extends Mutation implements PlatformBlockchainTransa
     /**
      * Get the mutation's attributes.
      */
+    #[\Override]
     public function attributes(): array
     {
         return [
@@ -65,6 +66,7 @@ class CreateListingMutation extends Mutation implements PlatformBlockchainTransa
     /**
      * Get the mutation's arguments definition.
      */
+    #[\Override]
     public function args(): array
     {
         return [
@@ -129,14 +131,13 @@ class CreateListingMutation extends Mutation implements PlatformBlockchainTransa
             listingData: Arr::get($args, 'listingData'),
         ));
 
-        ray($encodedData);
-
         return Transaction::lazyLoadSelectFields(
             DB::transaction(fn () => $this->storeTransaction($args, $encodedData)),
             $resolveInfo
         );
     }
 
+    #[\Override]
     public static function getEncodableParams(...$params): array
     {
         $makeAsset = Arr::get($params, 'makeAssetId', new MultiTokensTokenAssetIdParams('0', '0'));

--- a/src/GraphQL/Types/Input/AuctionParamsInputType.php
+++ b/src/GraphQL/Types/Input/AuctionParamsInputType.php
@@ -27,8 +27,9 @@ class AuctionParamsInputType extends InputType
     {
         return [
             'startBlock' => [
-                'type' => GraphQL::type('Int!'),
+                'type' => GraphQL::type('Int'),
                 'description' => __('enjin-platform-marketplace::type.auction_data.field.startBlock'),
+                'deprecationReason' => __('enjin-platform-marketplace::deprecated.auction_data.field.startBlock'),
             ],
             'endBlock' => [
                 'type' => GraphQL::type('Int!'),

--- a/src/Models/Substrate/AuctionDataParams.php
+++ b/src/Models/Substrate/AuctionDataParams.php
@@ -25,7 +25,7 @@ class AuctionDataParams
 
         return [
             'startBlock' => $this->startBlock,
-            'endBlock' => $this->endBlock
+            'endBlock' => $this->endBlock,
         ];
     }
 }

--- a/src/Models/Substrate/AuctionDataParams.php
+++ b/src/Models/Substrate/AuctionDataParams.php
@@ -8,8 +8,8 @@ class AuctionDataParams
      * Create a new instance of the model.
      */
     public function __construct(
-        public int $startBlock,
         public int $endBlock,
+        public ?int $startBlock = null,
     ) {}
 
     /**
@@ -17,6 +17,15 @@ class AuctionDataParams
      */
     public function toEncodable(): array
     {
-        return ['startBlock' => $this->startBlock, 'endBlock' => $this->endBlock];
+        if (currentSpec() >= 1020) {
+            return [
+                'endBlock' => $this->endBlock,
+            ];
+        }
+
+        return [
+            'startBlock' => $this->startBlock,
+            'endBlock' => $this->endBlock
+        ];
     }
 }

--- a/src/Services/Processor/Substrate/Codec/Encoder.php
+++ b/src/Services/Processor/Substrate/Codec/Encoder.php
@@ -8,6 +8,7 @@ class Encoder extends BaseEncoder
 {
     protected static array $callIndexKeys = [
         'CreateListing' => 'Marketplace.create_listing',
+        'CreateListingV1013' => 'Marketplace.create_listing',
         'CancelListing' => 'Marketplace.cancel_listing',
         'FillListing' => 'Marketplace.fill_listing',
         'FinalizeAuction' => 'Marketplace.finalize_auction',

--- a/tests/Feature/GraphQL/Mutations/CreateListingTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateListingTest.php
@@ -427,8 +427,6 @@ class CreateListingTest extends TestCaseGraphQL
             true
         );
 
-        ray($response['error']);
-
         $this->assertArrayContainsArray(
             ['salt' => ['The salt field must have a value.']],
             $response['error']

--- a/tests/Feature/GraphQL/Mutations/PlaceBidTest.php
+++ b/tests/Feature/GraphQL/Mutations/PlaceBidTest.php
@@ -135,7 +135,7 @@ class PlaceBidTest extends TestCaseGraphQL
             array_merge($data, ['price' => $price - 1]),
             true
         );
-        $expected = bcmul($price, 1.05);
+        $expected = bcmul((string) $price, 1.05);
         $this->assertArrayContainsArray(
             ['price' => ["The minimum bidding price must be greater than or equal to {$expected}."]],
             $response['error']

--- a/tests/Feature/GraphQL/Resources/CreateListing.graphql
+++ b/tests/Feature/GraphQL/Resources/CreateListing.graphql
@@ -4,6 +4,7 @@ mutation CreateListing(
   $amount: BigInt!
   $price: BigInt!
   $salt: String!
+  $startBlock: Int
   $listingData: ListingDataInput!
   $signingAccount: String
   $skipValidation: Boolean
@@ -14,6 +15,7 @@ mutation CreateListing(
     amount: $amount
     price: $price
     salt: $salt
+    startBlock: $startBlock
     listingData: $listingData
     signingAccount: $signingAccount
     skipValidation: $skipValidation

--- a/tests/Feature/GraphQL/Traits/CreateListingParameters.php
+++ b/tests/Feature/GraphQL/Traits/CreateListingParameters.php
@@ -23,10 +23,10 @@ trait CreateListingParameters
             'amount' => fake()->numberBetween(1, 1000),
             'price' => fake()->numberBetween(1, 1000),
             'salt' => fake()->text(10),
+            'startBlock' => fake()->numberBetween(1011, 5000),
             'listingData' => [
                 'type' => ListingType::AUCTION->name,
                 'auctionParams' => [
-                    'startBlock' => fake()->numberBetween(1011, 5000),
                     'endBlock' => fake()->numberBetween(5001, 10000),
                 ],
             ],

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,9 +3,11 @@
 namespace Enjin\Platform\Marketplace\Tests;
 
 use Enjin\Platform\CoreServiceProvider;
+use Enjin\Platform\Enums\Global\PlatformCache;
 use Enjin\Platform\Marketplace\MarketplaceServiceProvider;
 use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
@@ -38,6 +40,11 @@ abstract class TestCase extends BaseTestCase
         $app->useEnvironmentPath(__DIR__ . '/..');
         $app->useDatabasePath(__DIR__ . '/../database');
         $app->bootstrapWith([LoadEnvironmentVariables::class]);
+
+        ray($app['config']);
+
+        Cache::rememberForever(PlatformCache::SPEC_VERSION->key(currentMatrix()->value), fn () => 1020);
+        Cache::rememberForever(PlatformCache::TRANSACTION_VERSION->key(currentMatrix()->value), fn () => 11);
 
         $app['config']->set('database.default', env('DB_DRIVER', 'mysql'));
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -41,8 +41,6 @@ abstract class TestCase extends BaseTestCase
         $app->useDatabasePath(__DIR__ . '/../database');
         $app->bootstrapWith([LoadEnvironmentVariables::class]);
 
-        ray($app['config']);
-
         Cache::rememberForever(PlatformCache::SPEC_VERSION->key(currentMatrix()->value), fn () => 1020);
         Cache::rememberForever(PlatformCache::TRANSACTION_VERSION->key(currentMatrix()->value), fn () => 11);
 

--- a/tests/Unit/EncodingTest.php
+++ b/tests/Unit/EncodingTest.php
@@ -33,6 +33,7 @@ class EncodingTest extends TestCase
             amount: 1,
             price: 1,
             salt: 'test',
+            startBlock: 100,
             listingData: ['type' => ListingType::AUCTION->name, 'auctionParams' => [
                 'startBlock' => 100,
                 'endBlock' => 1000,
@@ -41,7 +42,7 @@ class EncodingTest extends TestCase
 
         $callIndex = $this->codec->encoder()->getCallIndex('Marketplace.create_listing', true);
         $this->assertEquals(
-            "0x{$callIndex}4277010004427701000404041074657374019101a10f00",
+            "0x{$callIndex}427701000442770100040404016400000010746573740001a10f00",
             $data
         );
     }


### PR DESCRIPTION
### **PR Type**
- Enhancement



___

### **Description**
- Removed redundant override annotations.

- Updated mutation encoding for version-specific logic.

- Added new parameters (startBlock, usesWhitelist) for v1020.

- Updated call index keys for CreateListing versioning.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreateListingMutation.php</strong><dd><code>Update CreateListing mutation with version conditionals</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Mutations/CreateListingMutation.php

<li>Removed #[\Override] attributes from multiple methods.<br> <li> Modified TransactionSerializer::encode to append variant.<br> <li> Added 'startBlock': null and 'usesWhitelist': false.<br> <li> Adjusted mutation name based on currentSpec().


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-marketplace/pull/78/files#diff-a057c02713a16ae9972ab4e94e73c64d96fe43e6e382c90ca5d1f7c73f64d76e">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Encoder.php</strong><dd><code>Add call index for CreateListingV1013 mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Codec/Encoder.php

<li>Added 'CreateListingV1013' key mapping.<br> <li> Ensured backward compatibility in call index keys.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-marketplace/pull/78/files#diff-9cf4c9f5fbba52860e055d9fd9d792ee1341497b92819d63b7bb327e9459def4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>