### PR TITLE
[PLA-2215][PLA-2219] FillListing&FinalizeAuction support for v1020

### DIFF
--- a/src/GraphQL/Mutations/FillListingMutation.php
+++ b/src/GraphQL/Mutations/FillListingMutation.php
@@ -88,7 +88,7 @@ class FillListingMutation extends Mutation implements PlatformBlockchainTransact
         ResolveInfo $resolveInfo,
         Closure $getSelectFields,
     ) {
-        $encodedData = TransactionSerializer::encode($this->getMutationName() . currentSpec() >= 1020 ? '' : 'V1013', static::getEncodableParams(...$args));
+        $encodedData = TransactionSerializer::encode($this->getMutationName() . (currentSpec() >= 1020 ? '' : 'V1013'), static::getEncodableParams(...$args));
 
         return Transaction::lazyLoadSelectFields(
             DB::transaction(fn () => $this->storeTransaction($args, $encodedData)),
@@ -103,9 +103,9 @@ class FillListingMutation extends Mutation implements PlatformBlockchainTransact
         $royaltyCount = 0;
         if (currentSpec() >= 1020) {
             $listing = MarketplaceListing::firstWhere('id', $listingId);
-            $makeCollection = Collection::firstWhere('collection_chain_id', $listing->make_collection_chain_id);
-            $makeToken = Token::firstWhere(['collection_id' => $makeCollection->id, 'token_chain_id' => $listing->make_token_chain_id]);
-            if ($makeCollection->royalty_wallet_id !== null || $makeToken->royalty_wallet_id !== null) {
+            $makeCollection = Collection::firstWhere('collection_chain_id', $listing?->make_collection_chain_id);
+            $makeToken = Token::firstWhere(['collection_id' => $makeCollection?->id, 'token_chain_id' => $listing?->make_token_chain_id]);
+            if ($makeCollection?->royalty_wallet_id !== null || $makeToken?->royalty_wallet_id !== null) {
                 $royaltyCount = 1;
             }
         }

--- a/src/GraphQL/Mutations/FillListingMutation.php
+++ b/src/GraphQL/Mutations/FillListingMutation.php
@@ -12,7 +12,10 @@ use Enjin\Platform\GraphQL\Types\Input\Substrate\Traits\HasIdempotencyField;
 use Enjin\Platform\GraphQL\Types\Input\Substrate\Traits\HasSigningAccountField;
 use Enjin\Platform\GraphQL\Types\Input\Substrate\Traits\HasSimulateField;
 use Enjin\Platform\Interfaces\PlatformBlockchainTransaction;
+use Enjin\Platform\Marketplace\Models\Laravel\MarketplaceListing;
 use Enjin\Platform\Marketplace\Rules\ListingNotCancelled;
+use Enjin\Platform\Models\Collection;
+use Enjin\Platform\Models\Token;
 use Enjin\Platform\Models\Transaction;
 use Enjin\Platform\Rules\MaxBigInt;
 use Enjin\Platform\Rules\MinBigInt;
@@ -85,7 +88,7 @@ class FillListingMutation extends Mutation implements PlatformBlockchainTransact
         ResolveInfo $resolveInfo,
         Closure $getSelectFields,
     ) {
-        $encodedData = TransactionSerializer::encode($this->getMutationName(), static::getEncodableParams(...$args));
+        $encodedData = TransactionSerializer::encode($this->getMutationName() . currentSpec() >= 1020 ? '' : 'V1013', static::getEncodableParams(...$args));
 
         return Transaction::lazyLoadSelectFields(
             DB::transaction(fn () => $this->storeTransaction($args, $encodedData)),
@@ -96,9 +99,21 @@ class FillListingMutation extends Mutation implements PlatformBlockchainTransact
     #[\Override]
     public static function getEncodableParams(...$params): array
     {
+        $listingId = Arr::get($params, 'listingId');
+        $royaltyCount = 0;
+        if (currentSpec() >= 1020) {
+            $listing = MarketplaceListing::firstWhere('id', $listingId);
+            $makeCollection = Collection::firstWhere('collection_chain_id', $listing->make_collection_chain_id);
+            $makeToken = Token::firstWhere(['collection_id' => $makeCollection->id, 'token_chain_id' => $listing->make_token_chain_id]);
+            if ($makeCollection->royalty_wallet_id !== null || $makeToken->royalty_wallet_id !== null) {
+                $royaltyCount = 1;
+            }
+        }
+
         return [
-            'listingId' => HexConverter::unPrefix(Arr::get($params, 'listingId', 0)),
+            'listingId' => HexConverter::unPrefix($listingId),
             'amount' => gmp_init(Arr::get($params, 'amount', 0)),
+            'royaltyBeneficiaryCount' => $royaltyCount,
         ];
     }
 

--- a/src/GraphQL/Mutations/FinalizeAuctionMutation.php
+++ b/src/GraphQL/Mutations/FinalizeAuctionMutation.php
@@ -13,6 +13,7 @@ use Enjin\Platform\GraphQL\Types\Input\Substrate\Traits\HasSigningAccountField;
 use Enjin\Platform\GraphQL\Types\Input\Substrate\Traits\HasSimulateField;
 use Enjin\Platform\Interfaces\PlatformBlockchainTransaction;
 use Enjin\Platform\Marketplace\Rules\ListingNotCancelled;
+use Facades\Enjin\Platform\Marketplace\Services\MarketplaceService;
 use Enjin\Platform\Models\Transaction;
 use Enjin\Platform\Rules\ValidHex;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -79,7 +80,7 @@ class FinalizeAuctionMutation extends Mutation implements PlatformBlockchainTran
         ResolveInfo $resolveInfo,
         Closure $getSelectFields,
     ) {
-        $encodedData = TransactionSerializer::encode($this->getMutationName(), static::getEncodableParams(...$args));
+        $encodedData = TransactionSerializer::encode($this->getMutationName() . (currentSpec() >= 1020 ? '' : 'V1013'), static::getEncodableParams(...$args));
 
         return Transaction::lazyLoadSelectFields(
             DB::transaction(fn () => $this->storeTransaction($args, $encodedData)),
@@ -90,8 +91,11 @@ class FinalizeAuctionMutation extends Mutation implements PlatformBlockchainTran
     #[\Override]
     public static function getEncodableParams(...$params): array
     {
+        $count = MarketplaceService::getRoyaltyBeneficiaryCount($listingId = Arr::get($params, 'listingId'));
+
         return [
-            'listingId' => HexConverter::unPrefix(Arr::get($params, 'listingId', 0)),
+            'listingId' => HexConverter::unPrefix($listingId),
+            'royaltyBeneficiaryCount' => $count,
         ];
     }
 

--- a/src/Services/MarketplaceService.php
+++ b/src/Services/MarketplaceService.php
@@ -3,6 +3,8 @@
 namespace Enjin\Platform\Marketplace\Services;
 
 use Enjin\Platform\Marketplace\Models\MarketplaceListing;
+use Enjin\Platform\Models\Collection;
+use Enjin\Platform\Models\Token;
 use Illuminate\Database\Eloquent\Model;
 
 class MarketplaceService
@@ -29,5 +31,21 @@ class MarketplaceService
     public function insert(array $data): bool
     {
         return MarketplaceListing::insert($data);
+    }
+
+    public function getRoyaltyBeneficiaryCount(string $listingId): int
+    {
+        $royaltyCount = 0;
+
+        if (currentSpec() >= 1020) {
+            $listing = MarketplaceListing::firstWhere('id', $listingId);
+            $makeCollection = Collection::firstWhere('collection_chain_id', $listing?->make_collection_chain_id);
+            $makeToken = Token::firstWhere(['collection_id' => $makeCollection?->id, 'token_chain_id' => $listing?->make_token_chain_id]);
+            if ($makeCollection?->royalty_wallet_id !== null || $makeToken?->royalty_wallet_id !== null) {
+                $royaltyCount = 1;
+            }
+        }
+
+        return $royaltyCount;
     }
 }

--- a/src/Services/Processor/Substrate/Codec/Encoder.php
+++ b/src/Services/Processor/Substrate/Codec/Encoder.php
@@ -13,6 +13,7 @@ class Encoder extends BaseEncoder
         'FillListing' => 'Marketplace.fill_listing',
         'FillListingV1013' => 'Marketplace.fill_listing',
         'FinalizeAuction' => 'Marketplace.finalize_auction',
+        'FinalizeAuctionV1013' => 'Marketplace.finalize_auction',
         'PlaceBid' => 'Marketplace.place_bid',
         'SetProtocolFee' => 'Marketplace.set_protocol_fee',
     ];

--- a/src/Services/Processor/Substrate/Codec/Encoder.php
+++ b/src/Services/Processor/Substrate/Codec/Encoder.php
@@ -11,6 +11,7 @@ class Encoder extends BaseEncoder
         'CreateListingV1013' => 'Marketplace.create_listing',
         'CancelListing' => 'Marketplace.cancel_listing',
         'FillListing' => 'Marketplace.fill_listing',
+        'FillListingV1013' => 'Marketplace.fill_listing',
         'FinalizeAuction' => 'Marketplace.finalize_auction',
         'PlaceBid' => 'Marketplace.place_bid',
         'SetProtocolFee' => 'Marketplace.set_protocol_fee',

--- a/tests/Feature/GraphQL/Mutations/FillListingTest.php
+++ b/tests/Feature/GraphQL/Mutations/FillListingTest.php
@@ -37,6 +37,7 @@ class FillListingTest extends TestCaseGraphQL
             $this->method,
             $params = ['listingId' => '0x' . fake()->regexify('[a-f0-9]{64}'), 'amount' => fake()->numberBetween(1, 1000), 'skipValidation' => true]
         );
+
         $this->assertEquals(
             $response['encodedData'],
             TransactionSerializer::encode($this->method, FillListingMutation::getEncodableParams(...$params))

--- a/tests/Unit/EncodingTest.php
+++ b/tests/Unit/EncodingTest.php
@@ -69,7 +69,7 @@ class EncodingTest extends TestCase
 
         $callIndex = $this->codec->encoder()->getCallIndex('Marketplace.fill_listing', true);
         $this->assertEquals(
-            "0x{$callIndex}002ddf91ca0f13b03541dbddb3a008d8efc975b0044fde799ea7ffe33fdf57f7a10f",
+            "0x{$callIndex}002ddf91ca0f13b03541dbddb3a008d8efc975b0044fde799ea7ffe33fdf57f7a10f00000000",
             $data
         );
     }


### PR DESCRIPTION
### **PR Type**
- Enhancement



___

### **Description**
- Update FillListing mutation encoding for spec v1020

- Introduce royaltyBeneficiaryCount in mutation parameters

- Add conditional version suffix when encoding transaction

- Adjust tests and encoder mapping for versioned call index


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FillListingMutation.php</strong><dd><code>Update mutation encoding with spec and royalty checks</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Mutations/FillListingMutation.php

<li>Condition to append 'V1013' based on spec version<br> <li> Introduce royaltyCount and new field 'royaltyBeneficiaryCount'<br> <li> Query MarketplaceListing, Collection, and Token for royalties


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-marketplace/pull/79/files#diff-8071ce0bd2f3b0dbfdd008b941c6787d696c5694a119b5dcf99842ff332b1841">+17/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Encoder.php</strong><dd><code>Add encoder mapping for versioned fill listing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Codec/Encoder.php

- Added call index mapping for 'FillListingV1013'


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-marketplace/pull/79/files#diff-9cf4c9f5fbba52860e055d9fd9d792ee1341497b92819d63b7bb327e9459def4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FillListingTest.php</strong><dd><code>Adjust test for fill listing mutation with updated params</code></dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/FillListingTest.php

<li>Inserted blank line for test clarity<br> <li> Verified lazy loaded transaction encoding with updated params


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-marketplace/pull/79/files#diff-3838092df88dc7e07737616a8901aa375c3266ca01d032aab2d94aa92940c410">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EncodingTest.php</strong><dd><code>Fix expected encoding output for fill listing mutation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/EncodingTest.php

- Updated expected encoding string to include trailing zeros


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-marketplace/pull/79/files#diff-304632780535cba1fc76d5ae4d6cfca20af64a2f1fb2e4a782300d6035017d2e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>